### PR TITLE
Ros2 - fixing paths to download and find models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,13 @@ find_package(ament_cmake REQUIRED)
 find_package(gazebo_ros REQUIRED)
 
 exec_program("python3 -m pip install -r ${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt")
-exec_program("python3 ${CMAKE_CURRENT_SOURCE_DIR}/fuel_utility.py download -m XRayMachine -m IVStand -m BloodPressureMonitor -m BPCart -m BMWCart -m CGMClassic -m StorageRack -m Chair -m InstrumentCart1 -m Scrubs -m PatientWheelChair -m WhiteChipChair -m TrolleyBed -m SurgicalTrolley -m PotatoChipChair -m VisitorKidSit -m FemaleVisitorSit -m AdjTable -m MopCart3 -m MaleVisitorSit -m Drawer -m OfficeChairBlack -m ElderLadyPatient -m ElderMalePatient -m InstrumentCart2 -m MetalCabinet -m BedTable -m BedsideTable -m AnesthesiaMachine -m TrolleyBedPatient -m Shower -m SurgicalTrolleyMed -m StorageRackCovered -m KitchenSink -m Toilet -m VendingMachine -m ParkingTrolleyMin -m PatientFSit -m MaleVisitorOnPhone -m FemaleVisitor -m MalePatientBed -m StorageRackCoverOpen -m ParkingTrolleyMax -d ${CMAKE_CURRENT_SOURCE_DIR}/fuel_models --verbose")
+exec_program("python3 ${CMAKE_CURRENT_SOURCE_DIR}/fuel_utility.py download -m XRayMachine -m IVStand -m BloodPressureMonitor -m BPCart -m BMWCart -m CGMClassic -m StorageRack -m Chair -m InstrumentCart1 -m Scrubs -m PatientWheelChair -m WhiteChipChair -m TrolleyBed -m SurgicalTrolley -m PotatoChipChair -m VisitorKidSit -m FemaleVisitorSit -m AdjTable -m MopCart3 -m MaleVisitorSit -m Drawer -m OfficeChairBlack -m ElderLadyPatient -m ElderMalePatient -m InstrumentCart2 -m MetalCabinet -m BedTable -m BedsideTable -m AnesthesiaMachine -m TrolleyBedPatient -m Shower -m SurgicalTrolleyMed -m StorageRackCovered -m KitchenSink -m Toilet -m VendingMachine -m ParkingTrolleyMin -m PatientFSit -m MaleVisitorOnPhone -m FemaleVisitor -m MalePatientBed -m StorageRackCoverOpen -m ParkingTrolleyMax -d ${CMAKE_CURRENT_SOURCE_DIR}/models --verbose")
 
 ################################################################################
 # Install
 ################################################################################
 
-install(DIRECTORY launch models fuel_models worlds
+install(DIRECTORY launch models fuel_models worlds photos
 	DESTINATION share/${PROJECT_NAME}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ exec_program("python3 ${CMAKE_CURRENT_SOURCE_DIR}/fuel_utility.py download -m XR
 # Install
 ################################################################################
 
-install(DIRECTORY launch models fuel_models worlds photos
+install(DIRECTORY launch models worlds photos
 	DESTINATION share/${PROJECT_NAME}
 )
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We also reference the following models from https://app.ignitionrobotics.org/fue
     from launch.launch_description_sources import PythonLaunchDescriptionSource
     def generate_launch_description():
         hospital_pkg_dir = get_package_share_directory('aws_robomaker_hospital_world')
-        hospital_launch_path = os.path.join(warehouse_pkg_dir, 'launch')
+        hospital_launch_path = os.path.join(hospital_pkg_dir, 'launch')
         hospital_world_cmd = IncludeLaunchDescription(
             PythonLaunchDescriptionSource([hospital_launch_path, '/hospital.launch.py'])
         )
@@ -82,4 +82,3 @@ $ chmod +x setup.sh
 $ ./setup.sh
 $ colcon build
 ```
-

--- a/README.md
+++ b/README.md
@@ -82,3 +82,10 @@ $ chmod +x setup.sh
 $ ./setup.sh
 $ colcon build
 ```
+
+# Notes
+It is possible that the Gazebo model path does not work properly, try the next command before running:
+
+```bash
+$ source /usr/share/gazebo/setup.bash
+```

--- a/setup.sh
+++ b/setup.sh
@@ -14,4 +14,4 @@ python3 fuel_utility.py download \
 -m Toilet -m VendingMachine -m ParkingTrolleyMin -m PatientFSit \
 -m MaleVisitorOnPhone -m FemaleVisitor -m MalePatientBed \
 -m StorageRackCoverOpen -m ParkingTrolleyMax \
--d fuel_models --verbose
+-d models --verbose

--- a/worlds/hospital.world
+++ b/worlds/hospital.world
@@ -1,6 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <sdf version="1.6">
   <world name="world">
+    <gui>
+      <camera name='gzclient_camera'>
+        <pose>-4.70385 10.895 16.2659 -0 0.921795 -1.12701</pose>
+      </camera>
+    </gui>
     <gravity>0 0 -9.8</gravity>
     <physics default="0" name="default_physics" type="ode">
       <max_step_size>0.001</max_step_size>

--- a/worlds/hospital_three_floors.world
+++ b/worlds/hospital_three_floors.world
@@ -1,6 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <sdf version="1.6">
   <world name="world">
+    <gui>
+      <camera name='gzclient_camera'>
+        <pose>-4.70385 10.895 16.2659 -0 0.921795 -1.12701</pose>
+      </camera>
+    </gui>
     <gravity>0 0 -9.8</gravity>
     <physics default="0" name="default_physics" type="ode">
       <max_step_size>0.001</max_step_size>

--- a/worlds/hospital_two_floors.world
+++ b/worlds/hospital_two_floors.world
@@ -1,6 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <sdf version="1.6">
   <world name="world">
+    <gui>
+      <camera name='gzclient_camera'>
+        <pose>-4.70385 10.895 16.2659 -0 0.921795 -1.12701</pose>
+      </camera>
+    </gui>
     <gravity>0 0 -9.8</gravity>
     <physics default="0" name="default_physics" type="ode">
       <max_step_size>0.001</max_step_size>


### PR DESCRIPTION
*Issue #, if available:*

1. Error in the readme file for launcher example
2. Fuel models are downloaded in a folder but .dae files try to find them in the model folder
3. Wrong camera position at starting
4. GAZEBO_MODEL_PATH is wrong, exports sometime fail and it is fixed using the gazebo setup.bash

*Description of changes:*

1. Fixed readme
2. Changed CMakelist.txt and script to download models in the same folder
3. Changed camera position
4. Added a note to the readme file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
